### PR TITLE
ETags

### DIFF
--- a/src/XAPI.spec.ts
+++ b/src/XAPI.spec.ts
@@ -1,7 +1,7 @@
 import XAPI, { Agent, Statement, Activity, Attachment } from "./XAPI";
 import CryptoJS from "crypto-js";
 import { TextEncoder } from "util";
-import axios, { AxiosPromise } from "axios";
+import axios from "axios";
 
 interface WordArray {
     iv: string;
@@ -127,7 +127,7 @@ describe("statement resource", () => {
         .then((result) => {
             return xapi.getStatement({
                 statementId: result.data[0]
-            }) as AxiosPromise<Statement>;
+            });
         }).then((result) => {
             return expect(result.data).toHaveProperty("id");
         });
@@ -154,8 +154,9 @@ describe("statement resource", () => {
             return xapi.getStatement({
                 statementId: result.data[0],
                 attachments: true
-            }) as AxiosPromise<Statement>;
-        }).then((parts) => {
+            });
+        }).then((response) => {
+            const parts = response.data;
             const attachmentData: unknown = parts[1];
             return expect(attachmentData).toEqual(attachmentContent);
         });
@@ -177,7 +178,7 @@ describe("statement resource", () => {
         }).then(() => {
             return xapi.getVoidedStatement({
                 voidedStatementId: statementId
-            }) as AxiosPromise<Statement>;
+            });
         }).then((result) => {
             return expect(result.data).toHaveProperty("id");
         });

--- a/src/XAPI.spec.ts
+++ b/src/XAPI.spec.ts
@@ -56,7 +56,6 @@ function arrayBufferToWordArray(ab: ArrayBuffer): WordArray {
 describe("about resource", () => {
     test("can get about", () => {
         return expect(xapi.getAbout()).resolves.toEqual(expect.objectContaining({
-            extensions: expect.any(Object),
             version: expect.any(Array)
         }));
     });

--- a/src/XAPI.spec.ts
+++ b/src/XAPI.spec.ts
@@ -288,9 +288,12 @@ describe("activity profile resource", () => {
     });
 
     test("can set activity profile", () => {
-        return xapi.setActivityProfile(testActivity.id, testProfileId, testProfile)
+        return xapi.getActivityProfile(testActivity.id, testProfileId)
         .then((result) => {
-            return expect(result.data).toBeDefined();
+            return xapi.setActivityProfile(testActivity.id, testProfileId, testProfile, result.headers.etag, "If-Match")
+            .then((result) => {
+                return expect(result.data).toBeDefined();
+            });
         });
     });
 
@@ -339,8 +342,10 @@ describe("agent profile resource", () => {
     });
 
     test("can set agent profile", () => {
-        return xapi.setAgentProfile(testAgent, testProfileId, testProfile)
+        return xapi.getAgentProfile(testAgent, testProfileId)
         .then((result) => {
+            return xapi.setAgentProfile(testAgent, testProfileId, testProfile, result.headers.etag, "If-Match");
+        }).then((result) => {
             return expect(result.data).toBeDefined();
         });
     });

--- a/src/XAPI.ts
+++ b/src/XAPI.ts
@@ -5,7 +5,7 @@ import { AttachmentUsages, Resources, Verbs } from "./constants";
 import { parseMultiPart, createMultiPart, MultiPart, Part } from "./helpers/multiPart";
 import { getSearchQueryParamsAsObject } from "./helpers/getSearchQueryParamsAsObject";
 import { calculateISO8601Duration } from "./helpers/calculateISO8601Duration";
-import axios, { AxiosRequestConfig } from "axios";
+import axios, { AxiosRequestConfig, AxiosPromise } from "axios";
 
 export * from "./interfaces/XAPI";
 export * from "./interfaces/Statement";
@@ -33,37 +33,37 @@ export default class XAPI {
   }
 
   // About Resource
-  public getAbout(): Promise<About> {
+  public getAbout(): AxiosPromise<About> {
     return this.requestResource(Resources.ABOUT);
   }
 
   // Agents Resource
-  public getAgent(agent: Agent): Promise<Person> {
+  public getAgent(agent: Agent): AxiosPromise<Person> {
     return this.requestResource(Resources.AGENTS, {
       agent: agent
     });
   }
 
   // Statement Resource
-  public getStatement(query: GetStatementQuery): Promise<Statement | Part[]> {
+  public getStatement(query: GetStatementQuery): AxiosPromise<Statement> | Promise<Part[]> {
     return this.requestResource(Resources.STATEMENT, query);
   }
 
-  public getVoidedStatement(query: GetVoidedStatementQuery): Promise<Statement | Part[]> {
+  public getVoidedStatement(query: GetVoidedStatementQuery): AxiosPromise<Statement>  | Promise<Part[]> {
     return this.requestResource(Resources.STATEMENT, query);
   }
 
-  public getStatements(query?: GetStatementsQuery): Promise<StatementsResponse> {
+  public getStatements(query?: GetStatementsQuery): AxiosPromise<StatementsResponse> {
     return this.requestResource(Resources.STATEMENT, query);
   }
 
-  public getMoreStatements(more: string): Promise<StatementsResponse> {
+  public getMoreStatements(more: string): AxiosPromise<StatementsResponse> {
     const endpoint = new URL(this.endpoint);
     const url = `${endpoint.protocol}//${endpoint.host}${more}`;
     return this.requestURL(url);
   }
 
-  public sendStatement(statement: Statement, attachments?: ArrayBuffer[]): Promise<string[]> {
+  public sendStatement(statement: Statement, attachments?: ArrayBuffer[]): AxiosPromise<string[]> {
     if (attachments?.length) {
       const multiPart: MultiPart = createMultiPart(statement, attachments);
       return this.requestResource(Resources.STATEMENT, {}, {
@@ -79,7 +79,7 @@ export default class XAPI {
     }
   }
 
-  public voidStatement(actor: Actor, statementId: string): Promise<string[]> {
+  public voidStatement(actor: Actor, statementId: string): AxiosPromise<string[]> {
     const voidStatement: Statement = {
       actor,
       verb: Verbs.VOIDED,
@@ -95,7 +95,7 @@ export default class XAPI {
   }
 
   // State Resource
-  public createState(agent: Agent, activityId: string, stateId: string, state: {[key: string]: any}, registration?: string): Promise<void> {
+  public createState(agent: Agent, activityId: string, stateId: string, state: {[key: string]: any}, registration?: string): AxiosPromise<void> {
     return this.requestResource(Resources.STATE, {
       agent: agent,
       activityId: activityId,
@@ -109,7 +109,7 @@ export default class XAPI {
     });
   }
 
-  public setState(agent: Agent, activityId: string, stateId: string, state: {[key: string]: any}, registration?: string): Promise<void> {
+  public setState(agent: Agent, activityId: string, stateId: string, state: {[key: string]: any}, registration?: string): AxiosPromise<void> {
     return this.requestResource(Resources.STATE, {
       agent: agent,
       activityId: activityId,
@@ -123,7 +123,7 @@ export default class XAPI {
     });
   }
 
-  public getStates(agent: Agent, activityId: string, registration?: string): Promise<string[]> {
+  public getStates(agent: Agent, activityId: string, registration?: string): AxiosPromise<string[]> {
     return this.requestResource(Resources.STATE, {
       agent: agent,
       activityId: activityId,
@@ -133,7 +133,7 @@ export default class XAPI {
     });
   }
 
-  public getState(agent: Agent, activityId: string, stateId: string, registration?: string): Promise<{[key: string]: any}> {
+  public getState(agent: Agent, activityId: string, stateId: string, registration?: string): AxiosPromise<{[key: string]: any}> {
     return this.requestResource(Resources.STATE, {
       agent: agent,
       activityId: activityId,
@@ -144,7 +144,7 @@ export default class XAPI {
     });
   }
 
-  public deleteState(agent: Agent, activityId: string, stateId: string, registration?: string): Promise<void> {
+  public deleteState(agent: Agent, activityId: string, stateId: string, registration?: string): AxiosPromise<void> {
     return this.requestResource(Resources.STATE, {
       agent: agent,
       activityId: activityId,
@@ -157,7 +157,7 @@ export default class XAPI {
     });
   }
 
-  public deleteStates(agent: Agent, activityId: string, registration?: string): Promise<void> {
+  public deleteStates(agent: Agent, activityId: string, registration?: string): AxiosPromise<void> {
     return this.requestResource(Resources.STATE, {
       agent: agent,
       activityId: activityId,
@@ -170,14 +170,14 @@ export default class XAPI {
   }
 
   // Activities Resource
-  public getActivity(activityId: string): Promise<Activity> {
+  public getActivity(activityId: string): AxiosPromise<Activity> {
     return this.requestResource(Resources.ACTIVITIES, {
       activityId: activityId
     });
   }
 
   // Activity Profile Resource
-  public createActivityProfile(activityId: string, profileId: string, profile: {[key: string]: any}): Promise<void> {
+  public createActivityProfile(activityId: string, profileId: string, profile: {[key: string]: any}): AxiosPromise<void> {
     return this.requestResource(Resources.ACTIVITY_PROFILE, {
       activityId: activityId,
       profileId: profileId
@@ -187,7 +187,7 @@ export default class XAPI {
     });
   }
 
-  public setActivityProfile(activityId: string, profileId: string, profile: {[key: string]: any}): Promise<void> {
+  public setActivityProfile(activityId: string, profileId: string, profile: {[key: string]: any}): AxiosPromise<void> {
     return this.requestResource(Resources.ACTIVITY_PROFILE, {
       activityId: activityId,
       profileId: profileId
@@ -197,20 +197,20 @@ export default class XAPI {
     });
   }
 
-  public getActivityProfiles(activityId: string): Promise<string[]> {
+  public getActivityProfiles(activityId: string): AxiosPromise<string[]> {
     return this.requestResource(Resources.ACTIVITY_PROFILE, {
       activityId: activityId
     });
   }
 
-  public getActivityProfile(activityId: string, profileId: string): Promise<{[key: string]: any}> {
+  public getActivityProfile(activityId: string, profileId: string): AxiosPromise<{[key: string]: any}> {
     return this.requestResource(Resources.ACTIVITY_PROFILE, {
       activityId: activityId,
       profileId: profileId
     });
   }
 
-  public deleteActivityProfile(activityId: string, profileId: string): Promise<void> {
+  public deleteActivityProfile(activityId: string, profileId: string): AxiosPromise<void> {
     return this.requestResource(Resources.ACTIVITY_PROFILE, {
       activityId: activityId,
       profileId: profileId
@@ -220,7 +220,7 @@ export default class XAPI {
   }
 
   // Agent Profile Resource
-  public createAgentProfile(agent: Agent, profileId: string, profile: {[key: string]: any}): Promise<void> {
+  public createAgentProfile(agent: Agent, profileId: string, profile: {[key: string]: any}): AxiosPromise<void> {
     return this.requestResource(Resources.AGENT_PROFILE, {
       agent: agent,
       profileId: profileId
@@ -230,7 +230,7 @@ export default class XAPI {
     });
   }
 
-  public setAgentProfile(agent: Agent, profileId: string, profile: {[key: string]: any}): Promise<void> {
+  public setAgentProfile(agent: Agent, profileId: string, profile: {[key: string]: any}): AxiosPromise<void> {
     return this.requestResource(Resources.AGENT_PROFILE, {
       agent: agent,
       profileId: profileId
@@ -240,20 +240,20 @@ export default class XAPI {
     });
   }
 
-  public getAgentProfiles(agent: Agent): Promise<string[]> {
+  public getAgentProfiles(agent: Agent): AxiosPromise<string[]> {
     return this.requestResource(Resources.AGENT_PROFILE, {
       agent: agent
     });
   }
 
-  public getAgentProfile(agent: Agent, profileId: string): Promise<{[key: string]: any}> {
+  public getAgentProfile(agent: Agent, profileId: string): AxiosPromise<{[key: string]: any}> {
     return this.requestResource(Resources.AGENT_PROFILE, {
       agent: agent,
       profileId: profileId
     });
   }
 
-  public deleteAgentProfile(agent: Agent, profileId: string): Promise<void> {
+  public deleteAgentProfile(agent: Agent, profileId: string): AxiosPromise<void> {
     return this.requestResource(Resources.AGENT_PROFILE, {
       agent: agent,
       profileId: profileId
@@ -262,12 +262,12 @@ export default class XAPI {
     });
   }
 
-  private requestResource(resource: Resource, params: RequestParams = {}, initExtras?: AxiosRequestConfig | undefined): Promise<any> {
+  private requestResource(resource: Resource, params: RequestParams = {}, initExtras?: AxiosRequestConfig | undefined): AxiosPromise<any> | Promise<any> {
     const url = this.generateURL(resource, params);
     return this.requestURL(url, initExtras);
   }
 
-  private requestURL(url: string, initExtras?: AxiosRequestConfig | undefined): Promise<any> {
+  private requestURL(url: string, initExtras?: AxiosRequestConfig | undefined): AxiosPromise<any> | Promise<any> {
     return axios({
       method: initExtras?.method || "GET",
       url: url,
@@ -280,9 +280,9 @@ export default class XAPI {
     }).then((response) => {
       const contentType = response.headers["content-type"];
       if (!contentType || contentType.indexOf("application/json") !== -1) {
-        return response.data;
+        return response;
       } else {
-        return response.data.indexOf("--") === 2 ? parseMultiPart(response.data) : response.data;
+        return response.data.indexOf("--") === 2 ? parseMultiPart(response.data) : response;
       }
     });
   }

--- a/src/XAPI.ts
+++ b/src/XAPI.ts
@@ -278,7 +278,8 @@ export default class XAPI {
       data: initExtras?.data,
       
     }).then((response) => {
-      if (response.headers["content-type"].indexOf("application/json") !== -1) {
+      const contentType = response.headers["content-type"];
+      if (!contentType || contentType.indexOf("application/json") !== -1) {
         return response.data;
       } else {
         return response.data.indexOf("--") === 2 ? parseMultiPart(response.data) : response.data;

--- a/src/XAPI.ts
+++ b/src/XAPI.ts
@@ -95,7 +95,9 @@ export default class XAPI {
   }
 
   // State Resource
-  public createState(agent: Agent, activityId: string, stateId: string, state: {[key: string]: any}, registration?: string): AxiosPromise<void> {
+  public createState(agent: Agent, activityId: string, stateId: string, state: {[key: string]: any}, registration?: string, etag?: string, matchHeader?: "If-Match" | "If-None-Match"): AxiosPromise<void> {
+    const headers = {};
+    if (etag) headers[matchHeader] = etag;
     return this.requestResource(Resources.STATE, {
       agent: agent,
       activityId: activityId,
@@ -105,11 +107,14 @@ export default class XAPI {
       } : {})
     }, {
       method: "POST",
-      data: state
+      data: state,
+      headers: headers
     });
   }
 
-  public setState(agent: Agent, activityId: string, stateId: string, state: {[key: string]: any}, registration?: string): AxiosPromise<void> {
+  public setState(agent: Agent, activityId: string, stateId: string, state: {[key: string]: any}, registration?: string, etag?: string, matchHeader?: "If-Match" | "If-None-Match"): AxiosPromise<void> {
+    const headers = {};
+    if (etag) headers[matchHeader] = etag;
     return this.requestResource(Resources.STATE, {
       agent: agent,
       activityId: activityId,
@@ -119,7 +124,8 @@ export default class XAPI {
       } : {})
     }, {
       method: "PUT",
-      data: state
+      data: state,
+      headers: headers
     });
   }
 
@@ -144,7 +150,9 @@ export default class XAPI {
     });
   }
 
-  public deleteState(agent: Agent, activityId: string, stateId: string, registration?: string): AxiosPromise<void> {
+  public deleteState(agent: Agent, activityId: string, stateId: string, registration?: string, etag?: string): AxiosPromise<void> {
+    const headers = {};
+    if (etag) headers["If-Match"] = etag;
     return this.requestResource(Resources.STATE, {
       agent: agent,
       activityId: activityId,
@@ -153,11 +161,14 @@ export default class XAPI {
         registration
       } : {})
     }, {
-      method: "DELETE"
+      method: "DELETE",
+      headers: headers
     });
   }
 
-  public deleteStates(agent: Agent, activityId: string, registration?: string): AxiosPromise<void> {
+  public deleteStates(agent: Agent, activityId: string, registration?: string, etag?: string): AxiosPromise<void> {
+    const headers = {};
+    if (etag) headers["If-Match"] = etag;
     return this.requestResource(Resources.STATE, {
       agent: agent,
       activityId: activityId,
@@ -165,7 +176,8 @@ export default class XAPI {
         registration
       } : {})
     }, {
-      method: "DELETE"
+      method: "DELETE",
+      headers: headers
     });
   }
 
@@ -177,23 +189,29 @@ export default class XAPI {
   }
 
   // Activity Profile Resource
-  public createActivityProfile(activityId: string, profileId: string, profile: {[key: string]: any}): AxiosPromise<void> {
+  public createActivityProfile(activityId: string, profileId: string, profile: {[key: string]: any}, etag?: string, matchHeader?: "If-Match" | "If-None-Match"): AxiosPromise<void> {
+    const headers = {};
+    if (etag) headers[matchHeader] = etag;
     return this.requestResource(Resources.ACTIVITY_PROFILE, {
       activityId: activityId,
       profileId: profileId
     }, {
       method: "POST",
-      data: profile
+      data: profile,
+      headers: headers
     });
   }
 
-  public setActivityProfile(activityId: string, profileId: string, profile: {[key: string]: any}): AxiosPromise<void> {
+  public setActivityProfile(activityId: string, profileId: string, profile: {[key: string]: any}, etag: string, matchHeader: "If-Match" | "If-None-Match"): AxiosPromise<void> {
+    const headers = {};
+    headers[matchHeader] = etag;
     return this.requestResource(Resources.ACTIVITY_PROFILE, {
       activityId: activityId,
       profileId: profileId
     }, {
       method: "PUT",
-      data: profile
+      data: profile,
+      headers: headers
     });
   }
 
@@ -210,33 +228,42 @@ export default class XAPI {
     });
   }
 
-  public deleteActivityProfile(activityId: string, profileId: string): AxiosPromise<void> {
+  public deleteActivityProfile(activityId: string, profileId: string, etag?: string): AxiosPromise<void> {
+    const headers = {};
+    if (etag) headers["If-Match"] = etag;
     return this.requestResource(Resources.ACTIVITY_PROFILE, {
       activityId: activityId,
       profileId: profileId
     }, {
-      method: "DELETE"
+      method: "DELETE",
+      headers: headers
     });
   }
 
   // Agent Profile Resource
-  public createAgentProfile(agent: Agent, profileId: string, profile: {[key: string]: any}): AxiosPromise<void> {
+  public createAgentProfile(agent: Agent, profileId: string, profile: {[key: string]: any}, etag?: string, matchHeader?: "If-Match" | "If-None-Match"): AxiosPromise<void> {
+    const headers = {};
+    if (etag) headers[matchHeader] = etag;
     return this.requestResource(Resources.AGENT_PROFILE, {
       agent: agent,
       profileId: profileId
     }, {
       method: "POST",
-      data: profile
+      data: profile,
+      headers: headers
     });
   }
 
-  public setAgentProfile(agent: Agent, profileId: string, profile: {[key: string]: any}): AxiosPromise<void> {
+  public setAgentProfile(agent: Agent, profileId: string, profile: {[key: string]: any}, etag: string, matchHeader: "If-Match" | "If-None-Match"): AxiosPromise<void> {
+    const headers = {};
+    headers[matchHeader] = etag;
     return this.requestResource(Resources.AGENT_PROFILE, {
       agent: agent,
       profileId: profileId
     }, {
       method: "PUT",
-      data: profile
+      data: profile,
+      headers: headers
     });
   }
 
@@ -253,12 +280,15 @@ export default class XAPI {
     });
   }
 
-  public deleteAgentProfile(agent: Agent, profileId: string): AxiosPromise<void> {
+  public deleteAgentProfile(agent: Agent, profileId: string, etag?: string): AxiosPromise<void> {
+    const headers = {};
+    if (etag) headers["If-Match"] = etag;
     return this.requestResource(Resources.AGENT_PROFILE, {
       agent: agent,
       profileId: profileId
     }, {
-      method: "DELETE"
+      method: "DELETE",
+      headers: headers
     });
   }
 

--- a/src/XAPI.ts
+++ b/src/XAPI.ts
@@ -34,44 +34,45 @@ export default class XAPI {
 
   // About Resource
   public getAbout(): Promise<About> {
-    return this.request(Resources.ABOUT);
+    return this.requestResource(Resources.ABOUT);
   }
 
   // Agents Resource
   public getAgent(agent: Agent): Promise<Person> {
-    return this.request(Resources.AGENTS, {
+    return this.requestResource(Resources.AGENTS, {
       agent: agent
     });
   }
 
   // Statement Resource
   public getStatement(query: GetStatementQuery): Promise<Statement | Part[]> {
-    return this.request(Resources.STATEMENT, query);
+    return this.requestResource(Resources.STATEMENT, query);
   }
 
   public getVoidedStatement(query: GetVoidedStatementQuery): Promise<Statement | Part[]> {
-    return this.request(Resources.STATEMENT, query);
+    return this.requestResource(Resources.STATEMENT, query);
   }
 
   public getStatements(query?: GetStatementsQuery): Promise<StatementsResponse> {
-    return this.request(Resources.STATEMENT, query);
+    return this.requestResource(Resources.STATEMENT, query);
   }
 
   public getMoreStatements(more: string): Promise<StatementsResponse> {
-    const params: {[key: string]: any} = getSearchQueryParamsAsObject(more);
-    return this.request(Resources.STATEMENT, params);
+    const endpoint = new URL(this.endpoint);
+    const url = `${endpoint.protocol}//${endpoint.host}${more}`;
+    return this.requestURL(url);
   }
 
   public sendStatement(statement: Statement, attachments?: ArrayBuffer[]): Promise<string[]> {
     if (attachments?.length) {
       const multiPart: MultiPart = createMultiPart(statement, attachments);
-      return this.request(Resources.STATEMENT, {}, {
+      return this.requestResource(Resources.STATEMENT, {}, {
         method: "POST",
         headers: multiPart.header,
         data: multiPart.blob
       });
     } else {
-        return this.request(Resources.STATEMENT, {}, {
+        return this.requestResource(Resources.STATEMENT, {}, {
         method: "POST",
         data: statement
       });
@@ -87,7 +88,7 @@ export default class XAPI {
         id: statementId
       }
     };
-    return this.request(Resources.STATEMENT, {}, {
+    return this.requestResource(Resources.STATEMENT, {}, {
       method: "POST",
       data: voidStatement
     });
@@ -95,7 +96,7 @@ export default class XAPI {
 
   // State Resource
   public createState(agent: Agent, activityId: string, stateId: string, state: {[key: string]: any}, registration?: string): Promise<void> {
-    return this.request(Resources.STATE, {
+    return this.requestResource(Resources.STATE, {
       agent: agent,
       activityId: activityId,
       stateId: stateId,
@@ -109,7 +110,7 @@ export default class XAPI {
   }
 
   public setState(agent: Agent, activityId: string, stateId: string, state: {[key: string]: any}, registration?: string): Promise<void> {
-    return this.request(Resources.STATE, {
+    return this.requestResource(Resources.STATE, {
       agent: agent,
       activityId: activityId,
       stateId: stateId,
@@ -123,7 +124,7 @@ export default class XAPI {
   }
 
   public getStates(agent: Agent, activityId: string, registration?: string): Promise<string[]> {
-    return this.request(Resources.STATE, {
+    return this.requestResource(Resources.STATE, {
       agent: agent,
       activityId: activityId,
       ...(registration ? {
@@ -133,7 +134,7 @@ export default class XAPI {
   }
 
   public getState(agent: Agent, activityId: string, stateId: string, registration?: string): Promise<{[key: string]: any}> {
-    return this.request(Resources.STATE, {
+    return this.requestResource(Resources.STATE, {
       agent: agent,
       activityId: activityId,
       stateId: stateId,
@@ -144,7 +145,7 @@ export default class XAPI {
   }
 
   public deleteState(agent: Agent, activityId: string, stateId: string, registration?: string): Promise<void> {
-    return this.request(Resources.STATE, {
+    return this.requestResource(Resources.STATE, {
       agent: agent,
       activityId: activityId,
       stateId: stateId,
@@ -157,7 +158,7 @@ export default class XAPI {
   }
 
   public deleteStates(agent: Agent, activityId: string, registration?: string): Promise<void> {
-    return this.request(Resources.STATE, {
+    return this.requestResource(Resources.STATE, {
       agent: agent,
       activityId: activityId,
       ...(registration ? {
@@ -170,14 +171,14 @@ export default class XAPI {
 
   // Activities Resource
   public getActivity(activityId: string): Promise<Activity> {
-    return this.request(Resources.ACTIVITIES, {
+    return this.requestResource(Resources.ACTIVITIES, {
       activityId: activityId
     });
   }
 
   // Activity Profile Resource
   public createActivityProfile(activityId: string, profileId: string, profile: {[key: string]: any}): Promise<void> {
-    return this.request(Resources.ACTIVITY_PROFILE, {
+    return this.requestResource(Resources.ACTIVITY_PROFILE, {
       activityId: activityId,
       profileId: profileId
     }, {
@@ -187,7 +188,7 @@ export default class XAPI {
   }
 
   public setActivityProfile(activityId: string, profileId: string, profile: {[key: string]: any}): Promise<void> {
-    return this.request(Resources.ACTIVITY_PROFILE, {
+    return this.requestResource(Resources.ACTIVITY_PROFILE, {
       activityId: activityId,
       profileId: profileId
     }, {
@@ -197,20 +198,20 @@ export default class XAPI {
   }
 
   public getActivityProfiles(activityId: string): Promise<string[]> {
-    return this.request(Resources.ACTIVITY_PROFILE, {
+    return this.requestResource(Resources.ACTIVITY_PROFILE, {
       activityId: activityId
     });
   }
 
   public getActivityProfile(activityId: string, profileId: string): Promise<{[key: string]: any}> {
-    return this.request(Resources.ACTIVITY_PROFILE, {
+    return this.requestResource(Resources.ACTIVITY_PROFILE, {
       activityId: activityId,
       profileId: profileId
     });
   }
 
   public deleteActivityProfile(activityId: string, profileId: string): Promise<void> {
-    return this.request(Resources.ACTIVITY_PROFILE, {
+    return this.requestResource(Resources.ACTIVITY_PROFILE, {
       activityId: activityId,
       profileId: profileId
     }, {
@@ -220,7 +221,7 @@ export default class XAPI {
 
   // Agent Profile Resource
   public createAgentProfile(agent: Agent, profileId: string, profile: {[key: string]: any}): Promise<void> {
-    return this.request(Resources.AGENT_PROFILE, {
+    return this.requestResource(Resources.AGENT_PROFILE, {
       agent: agent,
       profileId: profileId
     }, {
@@ -230,7 +231,7 @@ export default class XAPI {
   }
 
   public setAgentProfile(agent: Agent, profileId: string, profile: {[key: string]: any}): Promise<void> {
-    return this.request(Resources.AGENT_PROFILE, {
+    return this.requestResource(Resources.AGENT_PROFILE, {
       agent: agent,
       profileId: profileId
     }, {
@@ -240,20 +241,20 @@ export default class XAPI {
   }
 
   public getAgentProfiles(agent: Agent): Promise<string[]> {
-    return this.request(Resources.AGENT_PROFILE, {
+    return this.requestResource(Resources.AGENT_PROFILE, {
       agent: agent
     });
   }
 
   public getAgentProfile(agent: Agent, profileId: string): Promise<{[key: string]: any}> {
-    return this.request(Resources.AGENT_PROFILE, {
+    return this.requestResource(Resources.AGENT_PROFILE, {
       agent: agent,
       profileId: profileId
     });
   }
 
   public deleteAgentProfile(agent: Agent, profileId: string): Promise<void> {
-    return this.request(Resources.AGENT_PROFILE, {
+    return this.requestResource(Resources.AGENT_PROFILE, {
       agent: agent,
       profileId: profileId
     }, {
@@ -261,8 +262,12 @@ export default class XAPI {
     });
   }
 
-  private request(resource: Resource, params: RequestParams = {}, initExtras?: AxiosRequestConfig | undefined): Promise<any> {
+  private requestResource(resource: Resource, params: RequestParams = {}, initExtras?: AxiosRequestConfig | undefined): Promise<any> {
     const url = this.generateURL(resource, params);
+    return this.requestURL(url, initExtras);
+  }
+
+  private requestURL(url: string, initExtras?: AxiosRequestConfig | undefined): Promise<any> {
     return axios({
       method: initExtras?.method || "GET",
       url: url,


### PR DESCRIPTION
- Fixes #31 
- Fixes #22 
- Expanded responses to include entire Axios response (For ETag values)
- Fixed `getMoreStatements()`
- [x] Update documentation to reflect AxiosPromise/AxiosResponse on all calls
- [x] Update documentation to include `etag` and `matchHeader` properties on Resources