### PR TITLE
Switch to URLSearchParam to better handle edge cases in query param decoding.

### DIFF
--- a/src/helpers/getSearchQueryParamsAsObject.spec.ts
+++ b/src/helpers/getSearchQueryParamsAsObject.spec.ts
@@ -11,6 +11,12 @@ test("converts querystring into object", () => {
   });
 });
 
+test("can decode plus signs into spaces", () => {
+  return expect(getSearchQueryParamsAsObject("?test=Test+User")).toMatchObject({
+    test: "Test User",
+  });
+});
+
 test("converts relative URL with querystring into object", () => {
   return expect(
     getSearchQueryParamsAsObject("/lrs/test/statements?test=test")

--- a/src/helpers/getSearchQueryParamsAsObject.ts
+++ b/src/helpers/getSearchQueryParamsAsObject.ts
@@ -31,16 +31,12 @@ export function getSearchQueryParamsAsObject(
   const obj: { [key: string]: any } = {};
   const queryString = str.split("?")[1] || null;
   if (!queryString) return obj;
-  const items = queryString.split("&");
-  items.forEach((n: string) => {
-    const item: string[] = n.split("=");
-    const key = item[0];
-    const val = item[1];
-    const decodedItem: string = decodeURIComponent(val);
+  const usp = new URLSearchParams(queryString);
+  usp.forEach((val, key) => {
     try {
-      obj[key] = JSON.parse(decodedItem);
+      obj[key] = JSON.parse(val);
     } catch {
-      obj[key] = decodedItem;
+      obj[key] = val;
     }
     if (key === "actor") {
       obj.actor = coerceActor(obj.actor);


### PR DESCRIPTION
Addresses Issue #175.  Updated test included.