### PR TITLE
Cache busting

### DIFF
--- a/src/XAPI.ts
+++ b/src/XAPI.ts
@@ -436,7 +436,7 @@ export default class XAPI {
   public getActivityProfiles(
     activityId: string,
     since?: Timestamp,
-    useCacheBuster?: boolean,
+    useCacheBuster?: boolean
   ): AxiosPromise<string[]> {
     return this.requestResource(Resources.ACTIVITY_PROFILE, {
       activityId: activityId,
@@ -453,7 +453,7 @@ export default class XAPI {
   public getActivityProfile(
     activityId: string,
     profileId: string,
-    useCacheBuster?: boolean,
+    useCacheBuster?: boolean
   ): AxiosPromise<Document> {
     return this.requestResource(Resources.ACTIVITY_PROFILE, {
       activityId: activityId,


### PR DESCRIPTION
This is in relation to #222

adds something like `&cachebuster=1633729203` onto the query parameters in order to defeat browser caching and force the document to be re-downloaded from the LRS server.

I used the same kind of pattern that the `since` parameter uses with the spread operator and ternary expression.

Only implemented on getActivityProfile(s) since that's the only place where I have run into a need for it, though it might arguably apply to something like the agent profiles as well, or really anything that requestResource is called for, but I'm reluctant to go changing the signature of every single function.  Maybe it could be something that you configure on the `xapi` obect rather than passing it in to the function calls.

Anyhow, this is just a first pass to illustrate the idea, and is sufficient for my use case.

