### PR TITLE
Add cache-buster option to requestResource, make use of it in getActi…

### DIFF
--- a/src/XAPI.ts
+++ b/src/XAPI.ts
@@ -160,8 +160,12 @@ export default class XAPI {
   protected requestResource(
     resource: Resources,
     params: RequestParams = {},
-    initExtras?: AxiosRequestConfig | undefined
+    initExtras?: AxiosRequestConfig | undefined,
+    useCacheBuster?: boolean
   ): AxiosPromise<any> {
+    if (useCacheBuster) {
+      params["cachebuster"] = Math.round(new Date().getTime() / 1000);
+    }
     const url = this.generateURL(resource, params);
     return this.requestURL(url, initExtras);
   }

--- a/src/resources/document/activityProfile/getActivityProfile/getActivityProfile.ts
+++ b/src/resources/document/activityProfile/getActivityProfile/getActivityProfile.ts
@@ -6,10 +6,13 @@ import { Document } from "../../Document";
 
 export function getActivityProfile(
   this: XAPI,
-  params: GetActivityProfileParams
+  params: GetActivityProfileParams,
+  useCacheBuster?: boolean
 ): AxiosPromise<Document> {
   return this.requestResource(Resources.ACTIVITY_PROFILE, {
     activityId: params.activityId,
     profileId: params.profileId,
+    undefined,
+    useCacheBuster,
   });
 }


### PR DESCRIPTION
This is a version of the PR #223 but branched off the `feature/refactor` branch.  

I went one step further in making this generic by putting `useCacheBuster` as an optional parameter on the `requestResource` function, but still am only using it from one case.

I liked all of your suggestions that you wrote on #223 for how to proceed further with this, but like you say they will require some more widespread changes and more time investment.

I haven't gotten a chance to do anything further with this than just move this code over, and make sure it passes `yarn lint`.  I tried running the jest tests (after finding the `.env.example` and trying to copy to .env and add my credentials there) but still ran in to failures... error 500's.  So that's probably just because my ScormCloud account doesn't have whatever setup the tests are expecting.  I haven't tried using this new branch with my actual application yet either, I just wanted to get this out to you to continue the conversation and so that you didn't think I had completely ghosted you after you asked for further help  :)


