### PR TITLE
Fix hash polluting query string value

### DIFF
--- a/src/helpers/getSearchQueryParamsAsObject/getSearchQueryParamsAsObject.ts
+++ b/src/helpers/getSearchQueryParamsAsObject/getSearchQueryParamsAsObject.ts
@@ -29,9 +29,9 @@ export function getSearchQueryParamsAsObject(str: string): {
   [key: string]: any;
 } {
   const obj: { [key: string]: any } = {};
-  let queryString = str.split("?")[1] || "";
-  queryString = queryString.split("#")[0] || "";
-  if (queryString === "") return obj;
+  let queryString = str.substring(str.indexOf("?"));
+  queryString = queryString.split("#").shift();
+  if (!queryString) return obj;
   const usp = new URLSearchParams(queryString);
   usp.forEach((val, key) => {
     try {

--- a/src/helpers/getSearchQueryParamsAsObject/getSearchQueryParamsAsObject.ts
+++ b/src/helpers/getSearchQueryParamsAsObject/getSearchQueryParamsAsObject.ts
@@ -29,8 +29,9 @@ export function getSearchQueryParamsAsObject(str: string): {
   [key: string]: any;
 } {
   const obj: { [key: string]: any } = {};
-  const queryString = str.split("?")[1] || null;
-  if (!queryString) return obj;
+  let queryString = str.split("?")[1] || "";
+  queryString = queryString.split("#")[0] || "";
+  if (queryString === "") return obj;
   const usp = new URLSearchParams(queryString);
   usp.forEach((val, key) => {
     try {

--- a/src/helpers/getSearchQueryParamsAsObject/getSearchQueryParamsAsObject.unit.test.ts
+++ b/src/helpers/getSearchQueryParamsAsObject/getSearchQueryParamsAsObject.unit.test.ts
@@ -11,6 +11,14 @@ test("converts querystring into object", () => {
   });
 });
 
+test("converts querystring with hash into object", () => {
+  return expect(
+    getSearchQueryParamsAsObject("https://www.example.com?test=test#hash")
+  ).toMatchObject({
+    test: "test",
+  });
+});
+
 test("can decode plus signs into spaces", () => {
   return expect(getSearchQueryParamsAsObject("?test=Test+User")).toMatchObject({
     test: "Test User",

--- a/src/helpers/getSearchQueryParamsAsObject/getSearchQueryParamsAsObject.unit.test.ts
+++ b/src/helpers/getSearchQueryParamsAsObject/getSearchQueryParamsAsObject.unit.test.ts
@@ -19,6 +19,15 @@ test("converts querystring with hash into object", () => {
   });
 });
 
+test("converts querystring with multiple question marks into object", () => {
+  return expect(
+    getSearchQueryParamsAsObject("??test=test?&he?llo=wor?ld")
+  ).toMatchObject({
+    "?test": "test?",
+    "he?llo": "wor?ld",
+  });
+});
+
 test("can decode plus signs into spaces", () => {
   return expect(getSearchQueryParamsAsObject("?test=Test+User")).toMatchObject({
     test: "Test User",


### PR DESCRIPTION
Mentioned in https://github.com/xapijs/cmi5/pull/209:

- Adds support for hashes in query string parameters when using `getSearchQueryParamsAsObject`
- Adds support for multiple question marks in query string parameters when using `getSearchQueryParamsAsObject`