### PR TITLE
Issue 322/sub statement definition

### DIFF
--- a/src/resources/statement/Statement.ts
+++ b/src/resources/statement/Statement.ts
@@ -1,14 +1,24 @@
-import { Verb, StatementObject, Result, Context, Attachment, Actor } from ".";
+import {
+  Verb,
+  StatementObject,
+  Result,
+  Context,
+  Attachment,
+  Actor,
+  Timestamp,
+} from ".";
+import { Versions } from "../../constants";
 
 export interface Statement {
+  id?: string;
   actor: Actor;
   verb: Verb;
   object: StatementObject;
   result?: Result;
   context?: Context;
-  timestamp?: string;
-  stored?: string;
+  timestamp?: Timestamp;
+  stored?: Timestamp;
   authority?: Actor;
-  id?: string;
+  version?: Versions;
   attachments?: Attachment[];
 }

--- a/src/resources/statement/StatementObject.ts
+++ b/src/resources/statement/StatementObject.ts
@@ -1,6 +1,6 @@
 import {
   StatementRef,
-  Statement,
+  SubStatement,
   InteractionActivity,
   ObjectiveActivity,
   Actor,
@@ -13,4 +13,4 @@ export type StatementObject =
   | ObjectiveActivity
   | Actor
   | StatementRef
-  | Statement;
+  | SubStatement;

--- a/src/resources/statement/SubStatement.ts
+++ b/src/resources/statement/SubStatement.ts
@@ -1,0 +1,7 @@
+import { Statement, StatementObject } from ".";
+
+export interface SubStatement
+  extends Omit<Statement, "id" | "stored" | "version" | "authority"> {
+  objectType: "SubStatement";
+  object: Exclude<StatementObject, SubStatement>;
+}

--- a/src/resources/statement/index.ts
+++ b/src/resources/statement/index.ts
@@ -20,5 +20,6 @@ export * from "./StatementRef";
 export * from "./StatementResponseWithAttachments";
 export * from "./StatementsResponse";
 export * from "./StatementsResponseWithAttachments";
+export * from "./SubStatement";
 export * from "./Timestamp";
 export * from "./Verb";


### PR DESCRIPTION
Fixes https://github.com/xapijs/xapi/issues/322

- Added missing `version` property to `Statement`
- Corrected to `Timestamp` type for `stored` and `timestamp` properties on `Statement`
- Added missing `SubStatement` interface (See https://github.com/adlnet/xAPI-Spec/blob/master/xAPI-Data.md#substatements)
- Corrected `StatementObject` union type to use `SubStatement` instead of `Statement`